### PR TITLE
chore: add 24-hour package manager cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "minimumReleaseAge": "24 hours"
 }


### PR DESCRIPTION
Add minimumReleaseAge of 24 hours to Renovate config to avoid adopting broken or malicious package releases immediately.